### PR TITLE
fix: use absolute imports for utils to resolve Vercel build errors

### DIFF
--- a/apps/frontend/src/app/components/ui/button.jsx
+++ b/apps/frontend/src/app/components/ui/button.jsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva } from "class-variance-authority"
 
-import { cn } from "../../lib/utils.js"
+import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",

--- a/apps/frontend/src/app/components/ui/card.jsx
+++ b/apps/frontend/src/app/components/ui/card.jsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "../../lib/utils.js"
+import { cn } from "@/lib/utils"
 
 function Card({
   className,

--- a/apps/frontend/src/app/components/ui/checkbox.jsx
+++ b/apps/frontend/src/app/components/ui/checkbox.jsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
 import { Check } from "lucide-react"
 
-import { cn } from "../../lib/utils.js"
+import { cn } from "@/lib/utils"
 
 function Checkbox({
   className,

--- a/apps/frontend/src/app/components/ui/form.jsx
+++ b/apps/frontend/src/app/components/ui/form.jsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { Controller, FormProvider, useFormContext, useFormState } from "react-hook-form";
 
-import { cn } from "../../lib/utils.js"
+import { cn } from "@/lib/utils"
 import { Label } from "@/components/ui/label"
 
 const Form = FormProvider

--- a/apps/frontend/src/app/components/ui/input.jsx
+++ b/apps/frontend/src/app/components/ui/input.jsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "../../lib/utils.js"
+import { cn } from "@/lib/utils"
 
 function Input({
   className,

--- a/apps/frontend/src/app/components/ui/label.jsx
+++ b/apps/frontend/src/app/components/ui/label.jsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as LabelPrimitive from "@radix-ui/react-label"
 
-import { cn } from "../../lib/utils.js"
+import { cn } from "@/lib/utils"
 
 function Label({
   className,

--- a/apps/frontend/src/app/components/ui/progress.jsx
+++ b/apps/frontend/src/app/components/ui/progress.jsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as ProgressPrimitive from "@radix-ui/react-progress"
 
-import { cn } from '../../lib/utils.js'
+import { cn } from '@/lib/utils'
 
 function Progress({
   className,

--- a/apps/frontend/src/app/components/ui/radio-group.jsx
+++ b/apps/frontend/src/app/components/ui/radio-group.jsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
 import { Circle } from "lucide-react"
 
-import { cn } from "../../lib/utils.js"
+import { cn } from "@/lib/utils"
 
 function RadioGroup({
   className,

--- a/apps/frontend/src/app/components/ui/select.jsx
+++ b/apps/frontend/src/app/components/ui/select.jsx
@@ -4,7 +4,7 @@ import * as React from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
 
-import { cn } from "../../lib/utils.js"
+import { cn } from "@/lib/utils"
 
 function Select({
   ...props

--- a/apps/frontend/src/app/components/ui/slider.jsx
+++ b/apps/frontend/src/app/components/ui/slider.jsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import * as SliderPrimitive from "@radix-ui/react-slider"
 
-import { cn } from "../../lib/utils.js"
+import { cn } from "@/lib/utils"
 
 function Slider({
   className,

--- a/apps/frontend/src/app/components/ui/textarea.jsx
+++ b/apps/frontend/src/app/components/ui/textarea.jsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "../../lib/utils.js"
+import { cn } from "@/lib/utils"
 
 function Textarea({
   className,


### PR DESCRIPTION
- Move utils.js to src/lib directory for proper path resolution
- Update all UI components to use @/lib/utils absolute imports
- Fix module resolution issues preventing Vercel deployment
- Ensure compatibility with Next.js path mapping configuration
