### PR TITLE
refactor: remove HathiTrust integration

### DIFF
--- a/apps/backend/src/countries/us/config.py
+++ b/apps/backend/src/countries/us/config.py
@@ -24,21 +24,14 @@ API_CLIENTS_CONFIG = {
         "name": "Library of Congress",
         "base_url": "https://www.loc.gov",
         "rate_limit_delay": 1.0,
-        "confidence_weight": 0.4,
+        "confidence_weight": 0.6,
         "primary_use": "literary_works"
-    },
-    "hathitrust": {
-        "name": "HathiTrust Digital Library",
-        "base_url": "https://catalog.hathitrust.org/api",
-        "rate_limit_delay": 1.0,
-        "confidence_weight": 0.3,
-        "primary_use": "rights_information"
     },
     "musicbrainz": {
         "name": "MusicBrainz",
         "base_url": "https://musicbrainz.org/ws/2",
         "rate_limit_delay": 1.1,  # MusicBrainz requires 1 req/sec minimum
-        "confidence_weight": 0.3,
+        "confidence_weight": 0.4,
         "primary_use": "musical_works"
     }
 }
@@ -46,9 +39,8 @@ API_CLIENTS_CONFIG = {
 # Metadata normalization settings
 NORMALIZATION_CONFIG = {
     "confidence_weights": {
-        "loc": 0.4,
-        "hathitrust": 0.3,
-        "musicbrainz": 0.3
+        "loc": 0.6,
+        "musicbrainz": 0.4
     },
     "author_name_cleanup_patterns": [
         r'\s*\([^)]*\)',  # Remove dates in parentheses
@@ -75,7 +67,7 @@ ANALYSIS_CONFIG = {
 # Work type mappings
 WORK_TYPE_CONFIG = {
     "literary": {
-        "primary_apis": ["library_of_congress", "hathitrust"],
+        "primary_apis": ["library_of_congress"],
         "secondary_apis": [],
         "file_formats": ["book", "text", "manuscript"]
     },

--- a/apps/backend/src/utils/metadata_normalizer.py
+++ b/apps/backend/src/utils/metadata_normalizer.py
@@ -174,7 +174,6 @@ class MetadataNormalizer:
     @staticmethod
     def merge_api_responses(
         loc_response: Optional[APIResponse] = None,
-        hathi_response: Optional[APIResponse] = None,
         musicbrainz_response: Optional[APIResponse] = None,
         musicbrainz_artist_response: Optional[APIResponse] = None,
         search_title: str = "",
@@ -314,33 +313,6 @@ class MetadataNormalizer:
                 # No valid match found by LOC client
                 merged['confidence_sources']['loc'] = 0.0
         
-        # Process HathiTrust data
-        if hathi_response and hathi_response.success and hathi_response.data:
-            hathi_data = hathi_response.data
-            best_volume = hathi_data.get('best_volume')
-            
-            if best_volume:
-                # Title (if not already set or better match)
-                if best_volume.get('title') and (not merged['title'] or 
-                    hathi_response.confidence > merged['confidence_sources'].get('loc', 0)):
-                    merged['title'] = best_volume['title']
-                
-                # Publication year
-                pub_date = best_volume.get('publication_date', '')
-                pub_year = MetadataNormalizer.extract_publication_year(pub_date)
-                if pub_year and not merged['publication_year']:
-                    merged['publication_year'] = pub_year
-                
-                # Source link
-                if best_volume.get('url'):
-                    merged['source_links']['hathitrust'] = best_volume['url']
-                
-                # Rights information
-                rights_summary = hathi_data.get('rights_summary', {})
-                if rights_summary:
-                    merged['hathi_rights'] = rights_summary
-                
-                merged['confidence_sources']['hathitrust'] = hathi_response.confidence
         
         # Process MusicBrainz work data
         if musicbrainz_response and musicbrainz_response.success and musicbrainz_response.data:
@@ -425,7 +397,7 @@ class MetadataNormalizer:
         confidence_sources = merged_metadata.get('confidence_sources', {})
         if confidence_sources:
             # Average confidence weighted by source reliability
-            weights = {'loc': 0.4, 'hathitrust': 0.3, 'musicbrainz': 0.3}
+            weights = {'loc': 0.6, 'musicbrainz': 0.4}
             total_weight = 0
             weighted_confidence = 0
             


### PR DESCRIPTION
Remove HathiTrust API client and all related functionality:
- Remove HathiTrust client imports and initialization from US analyzer
- Remove HathiTrust configuration from API clients config
- Remove HathiTrust processing from metadata normalizer
- Update confidence weights: LOC (0.6), MusicBrainz (0.4)
- Simplify work type configuration to focus on LOC and MusicBrainz
- Update analyzer step numbering after HathiTrust removal

This focuses the system on Library of Congress (primary) and MusicBrainz (secondary) data sources for more reliable copyright analysis.